### PR TITLE
Add study top node without FAS visual attribute

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ click==6.7
 pandas>=0.22.0
 numpy>=1.9.0
 chardet==3.0.4
-tmtk>=0.5.3
+tmtk>=0.5.4
 psycopg2-binary>=2.7.4

--- a/scripts/transmart_transformation.py
+++ b/scripts/transmart_transformation.py
@@ -72,8 +72,8 @@ def main(csr_data_file, study_registry_data_file, output_dir,
         study_dir = os.path.dirname(csr_data_file)
         study.write_to(os.path.join(study_dir, study_id), overwrite=True)
 
-    tm_study = tmtk.toolbox.SkinnyExport(study, output_dir)
-    #tm_study.build_observation_fact()
+    # omit_fas=True will create study node with FA instead of FAS for c_visualattributes
+    tm_study = tmtk.toolbox.SkinnyExport(study, output_dir, omit_fas=True)
     tm_study.to_disk()
 
     sys.exit(0)


### PR DESCRIPTION
this will prevent Glowing Bear from add study constraints to every concept node.

PR relates to: https://github.com/thehyve/tmtk/pull/49 