### PR TITLE
Replace user-password with offline token when requesting an access token

### DIFF
--- a/luigi-pipeline/main.py
+++ b/luigi-pipeline/main.py
@@ -231,22 +231,19 @@ class TransmartDataLoader(ExternalProgramTask):
 class TransmartApiTask(BaseTask):
     keycloak_url = luigi.Parameter(description='URL of the keycloak instance, include the realm in the URL')
     client_id = luigi.Parameter(description='client_id of transmart client configured in keycloak')
-    client_secret = luigi.Parameter(description='client_secret of transmart client configured in keycloak')
+    offline_token = luigi.Parameter(description='offline_token used as refresh token to receive an actual access token,'
+                                                'configured in keycloak')
     transmart_url = luigi.Parameter(description='URL of the tranSMART instance', significant=False)
-    transmart_username = luigi.Parameter(description='Username for an admin account', significant=False)
-    transmart_password = luigi.Parameter(description='Password for the admin account', significant=False)
     gb_backend_url = luigi.Parameter(description='URL of the gb backend instance', significant=False)
 
     max_status_check_retrial = 240
 
     def run(self):
         reload_obj = TransmartApiCalls(keycloak_url=self.keycloak_url,
-                                       username=self.transmart_username,
-                                       password=self.transmart_password,
                                        transmart_url=self.transmart_url,
                                        gb_backend_url=self.gb_backend_url,
                                        client_id=self.client_id,
-                                       client_secret=self.client_secret)
+                                       offline_token=self.offline_token)
 
         logger.info('After data loading update; clearing and rebuilding caches, rebuilding subject sets')
         reload_obj.after_data_loading()

--- a/luigi.cfg-sample
+++ b/luigi.cfg-sample
@@ -83,9 +83,7 @@ keycloak_url = https://somekeycloak.net/auth/realms/transmart-name
 transmart_url = https://transmart.thehyve.net
 gb_backend_url = https://gb-backend.thehyve.net
 client_id = transmart
-client_secret = ''
-transmart_username = admin
-transmart_password = admin
+offline_token = <transmart-user-offline-token>
 
 [CbioportalDataTransformation]
 cbioportal_header_descriptions=cbioportal_header_descriptions.json

--- a/scripts/transmart_api_calls.py
+++ b/scripts/transmart_api_calls.py
@@ -10,15 +10,13 @@ class TransmartApiException(Exception):
 
 class TransmartApiCalls(object):
 
-    def __init__(self, keycloak_url, username, password, transmart_url, gb_backend_url, client_id, client_secret):
+    def __init__(self, keycloak_url, transmart_url, gb_backend_url, client_id, offline_token):
         self.url = keycloak_url
-        self.username = username
-        self.password = password
         self.token = None
         self.tm_url = transmart_url
         self.gb_backend_url = gb_backend_url
         self.client_id = client_id
-        self.client_secret = client_secret
+        self.offline_token = offline_token
 
     def get_token(self):
         """
@@ -32,18 +30,18 @@ class TransmartApiCalls(object):
 
     def retrieve_token(self):
         """
-        Retrieve access token from the server.
+        Retrieve an access token from Keycloak based on the client_id and the offline token,
+        which is stored in the config.
         """
         headers = {'Accept': 'application/json',
                    'Contect-Type': 'application/x-www-form-urlencoded'
                    }
         url = self.url + '/protocol/openid-connect/token'
         params = {
-            'grant_type': 'password',
+            'grant_type': 'refresh_token',
+            'scope': 'offline_access',
             'client_id': self.client_id,
-            'client_secret': self.client_secret,
-            'username': self.username,
-            'password': self.password
+            'refresh_token': self.offline_token
         }
         try:
             response = requests.post(url, params, headers=headers)


### PR DESCRIPTION
Use an offline token instead of user and password to request a Transmart access token from Keycloak.
Fixes [TMT-857](https://jira.thehyve.nl/browse/TMT-857)

There are a few actions required before deploying this change to a specific env:
- request an offline access for a specific env using pipeline user (it should already have an offline access permission),
- replace the user/password credentials in hiera configuration of puppet with the received refresh token,
- test the solution
