### PR TITLE
Add column priority unit tests

### DIFF
--- a/definitions.py
+++ b/definitions.py
@@ -3,8 +3,6 @@ from pathlib import Path
 # Project root dir
 ROOT_DIR = Path(__file__).parent.resolve()
 
-CONFIG_DIR = ROOT_DIR.joinpath('config')
-
 TEST_DATA_DIR = ROOT_DIR.joinpath('test_data')
 TESTS_DIR = ROOT_DIR.joinpath('tests')
 TEST_EXPECTED_OUT_DIR = TESTS_DIR.joinpath('expected_out')

--- a/tests/test_csr_transformations.py
+++ b/tests/test_csr_transformations.py
@@ -5,7 +5,7 @@ import unittest
 import pandas as pd
 
 import scripts.csr_transformations as ct
-from definitions import TEST_DATA_DIR, TEST_EXPECTED_OUT_DIR, CONFIG_DIR
+from definitions import TEST_DATA_DIR, TEST_EXPECTED_OUT_DIR, ROOT_DIR
 
 
 # TODO: Refactor test cases to not rely on production config
@@ -17,7 +17,7 @@ class CsrTransformationTests(unittest.TestCase):
         self.dummy_test_data = TEST_DATA_DIR.joinpath('dummy_data')
         self.missing_diag_data = TEST_DATA_DIR.joinpath('missing_diagnosis_date')
         self.test_config = TEST_DATA_DIR.joinpath('test_config')
-        self.config = CONFIG_DIR
+        self.config = ROOT_DIR.joinpath('config')
 
     def tearDown(self):
         pass


### PR DESCRIPTION
Add a unit test for each individual logging statement that can be triggered within the `check_column_prio` function.
Bugfix for index out of bounds call in logging statement.