### PR TITLE
Fix issue with asyncio loop being closed before completion.

### DIFF
--- a/luigi-pipeline/main.py
+++ b/luigi-pipeline/main.py
@@ -168,11 +168,7 @@ class TransmartApiTask(BaseTask):
         reload_obj.after_data_loading()
 
         logger.info('Waiting for the update to complete ...')
-        loop = asyncio.get_event_loop()
-        try:
-            loop.run_until_complete(reload_obj.check_status(self.max_status_check_retrial))
-        finally:
-            loop.close()
+        asyncio.run(reload_obj.check_status(self.max_status_check_retrial))
 
         logger.info('Scanning for new subscriptions')
         reload_obj.scan_subscription_queries()


### PR DESCRIPTION
Event looped fails with "Event loop is closed" before running the task.

Fixes PMCSD-42

As of Python 3.7, the process of creating, managing, then closing the loop (as well as a few other resources) is handled for you when use [asyncio.run()](https://docs.python.org/3/library/asyncio-task.html#asyncio.run).